### PR TITLE
fix: Shell injection hardening and auto-start race condition

### DIFF
--- a/app/api/get-sandbox-files/route.ts
+++ b/app/api/get-sandbox-files/route.ts
@@ -38,7 +38,13 @@ export async function GET(request: NextRequest) {
 
     for (const filePath of fileList) {
       try {
-        // Shell-escape file path to prevent injection from special characters
+        // Reject paths with suspicious characters (traversal, null bytes, shell metacharacters)
+        if (/[`$;\0|&]|\.\./.test(filePath)) {
+          console.warn(`[get-sandbox-files] Skipping suspicious path: ${filePath}`);
+          continue;
+        }
+
+        // Shell-escape: wrap in single quotes, escape embedded single quotes
         const safePath = filePath.replace(/'/g, "'\\''");
 
         // Check file size first

--- a/app/generation/page.tsx
+++ b/app/generation/page.tsx
@@ -235,12 +235,12 @@ function AISandboxPage() {
   // Auto-start generation from session flag
   useEffect(() => {
     const autoStart = sessionStorage.getItem('autoStart');
-    if (autoStart === 'true' && !showHomeScreen && homeUrlInput) {
+    if (autoStart === 'true' && !showHomeScreen && homeUrlInput && !loading) {
       sessionStorage.removeItem('autoStart');
       setTimeout(() => { startGeneration(); }, 1000);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showHomeScreen, homeUrlInput]);
+  }, [showHomeScreen, homeUrlInput, loading]);
 
   // Sandbox status check on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **get-sandbox-files**: Reject paths containing shell metacharacters (`` ` $ ; \0 | & ``) and `..` traversal before shell-escaping — addresses Greptile finding from PR #11
- **generation page**: Add `!loading` guard to auto-start useEffect so it waits for sandbox creation to complete before triggering first generation — addresses Greptile finding from PR #15

## Test plan
- [ ] Verify `get-sandbox-files` skips paths with metacharacters (log warning)
- [ ] Verify auto-start waits for sandbox loading before triggering generation
- [ ] No regressions in normal file listing or generation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)